### PR TITLE
Add move to cluster guide

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,7 @@
+Welcome to the guides section! These guides help you get more out of WidgetBot.
+
+!!! note
+  This tutorial assumes you have already completed the [Getting Started with WidgetBot](/tutorial) tutorial, or that WidgetBot has been added to your server and site.
+
+## Current Guides
+* [Moving to a cluster](/guides/move-to-cluster)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,7 +1,7 @@
 Welcome to the guides section! These guides help you get more out of WidgetBot.
 
 !!! note
-  This tutorial assumes you have already completed the [Getting Started with WidgetBot](/tutorial) tutorial, or that WidgetBot has been added to your server and site.
+    This tutorial assumes you have already completed the [Getting Started with WidgetBot](/tutorial) tutorial, or that WidgetBot has been added to your server and site.
 
 ## Current Guides
 * [Moving to a cluster](/guides/move-to-cluster)

--- a/docs/guides/move-to-cluster.md
+++ b/docs/guides/move-to-cluster.md
@@ -11,14 +11,14 @@ Discord now requires us to use sharding - something that will need to be worked 
 Alternatively, if you want beta features such as letting guests mention users and use custom emotes, use [the beta version](https://discordapp.com/oauth2/authorize?client_id=356856478495408129&scope=bot&permissions=537218112). Note that this may have bugs.
 
 !!! note
-  There is no difference between clusters 1 to 5.
+    There is no difference between clusters 1 through 5.
 
 ## How can I use a cluster?
 
 First, click on the link for a cluster and add the bot to your server.
 
 !!! note
-  The examples on this page use Cluster 1 (cl1), change it to the cluster you added to the server.
+    The examples on this page use Cluster 1 (cl1), change it to the cluster you added to the server.
   
 #### Jump to
 * [iframes](#iframes)
@@ -31,24 +31,24 @@ First, click on the link for a cluster and add the bot to your server.
 Preprend the cluster to the domain in the `src` url, for example `https://widgetbot.io/channels/34234/234432` => `https://cl4.widgetbot.io/channels/34234/234432`. For more info see [the iframe tutorial](/tutorial/iframes) (the cluster is the `shard`).
 
 !!! example "iframe example with cluster"
-  ```html
- <iframe src="https://cl1.widgetbot.io/channels/299881420891881473/355719584830980096" height="600" width="800"></iframe>
-  ```
+    ```html
+    <iframe src="https://cl1.widgetbot.io/channels/299881420891881473/355719584830980096" height="600" width="800"></iframe>
+    ```
 
 ### Crate
 
 Set the `shard` [option](/embed/crate/options):
 
 !!! example "Crate example with cluster"
-  ```html
-  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
-  new Crate({
-    server: '299881420891881473',
-    channel: '355719584830980096',
-    shard: 'https://cl1.widgetbot.io'
-   })
-  </script>
-  ```
+    ```html
+    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+      new Crate({
+        server: '299881420891881473',
+        channel: '355719584830980096',
+        shard: 'https://cl1.widgetbot.io'
+      })
+    </script>
+    ```
   
 For more info see [the Crate tutorial](/embed/crate/tutorial).
 
@@ -57,17 +57,16 @@ For more info see [the Crate tutorial](/embed/crate/tutorial).
 Add a `shard` [attribute](/embed/html-embed/attributes)
 
 !!! example "html-embed example with cluster"
-  ```html
-  <widgetbot
-    server="299881420891881473"
-    channel="355719584830980096"
-    width="800"
-    height="600"
-    shard="https://cl1.widgetbot.io"
-  ></widgetbot>
-  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/html-embed"></script>
-
-  ```
+    ```html
+    <widgetbot
+      server="299881420891881473"
+      channel="355719584830980096"
+      width="800"
+      height="600"
+      shard="https://cl1.widgetbot.io"
+    ></widgetbot>
+    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/html-embed"></script>
+    ```
 
 For more info see [the html-embed tutorial](/embed/html-embed/tutorial).
 
@@ -77,17 +76,17 @@ For more info see [the html-embed tutorial](/embed/html-embed/tutorial).
 Set the `shard` [prop](/embed/react-embed/props)
 
 !!! example "react-embed example with cluster"
-  ```js
-  import * as React from 'react'
-  import WidgetBot from '@widgetbot/react-embed'
-  
-  const App = () => (
-    <WidgetBot
-      server="299881420891881473"
-      channel="355719584830980096"
-      shard="https://cl1.widgetbot.io"
-   />
-  )
-
-  export default App
-  ```
+    ```js
+    import * as React from 'react'
+    import WidgetBot from '@widgetbot/react-embed'
+    
+    const App = () => (
+      <WidgetBot
+        server="299881420891881473"
+        channel="355719584830980096"
+        shard="https://cl1.widgetbot.io"
+      />
+    )
+    
+    export default App
+    ```

--- a/docs/guides/move-to-cluster.md
+++ b/docs/guides/move-to-cluster.md
@@ -28,12 +28,14 @@ First, click on the link for a cluster and add the bot to your server.
 
 ### iframes
 
-Preprend the cluster to the domain in the `src` url, for example `https://widgetbot.io/channels/34234/234432` => `https://cl4.widgetbot.io/channels/34234/234432`. For more info see [the iframe tutorial](/tutorial/iframes) (the cluster is the `shard`).
+Preprend the cluster to the domain in the `src` url, for example `https://widgetbot.io/channels/34234/234432` => `https://cl4.widgetbot.io/channels/34234/234432`.
 
 !!! example "iframe example with cluster"
     ```html
     <iframe src="https://cl1.widgetbot.io/channels/299881420891881473/355719584830980096" height="600" width="800"></iframe>
     ```
+
+For more info see [the iframe tutorial](/tutorial/iframes) (the cluster is the `shard`).
 
 ### Crate
 

--- a/docs/guides/move-to-cluster.md
+++ b/docs/guides/move-to-cluster.md
@@ -1,0 +1,93 @@
+Discord now requires us to use sharding - something that will need to be worked on. WidgetBot may display "unable to locate this server" to some users, randomly. This will be fixed soon.
+
+**In the meantime, we'd recommend all users to use one of the clusters**
+
+* [Cluster 1 (cl1)](https://discordapp.com/oauth2/authorize?client_id=454690519952523267&scope=bot&permissions=537218112)
+* [Cluster 2 (cl2)](https://discordapp.com/oauth2/authorize?client_id=454690621454548994&scope=bot&permissions=537218112)
+* [Cluster 3 (cl3)](https://discordapp.com/oauth2/authorize?client_id=454690769010425856&scope=bot&permissions=537218112)
+* [Cluster 4 (cl4)](https://discordapp.com/oauth2/authorize?client_id=454690860097863680&scope=bot&permissions=537218112)
+* [Cluster 5 (cl5)](https://discordapp.com/oauth2/authorize?client_id=454690940968370188&scope=bot&permissions=537218112)
+
+Alternatively, if you want beta features such as letting guests mention users and use custom emotes, use [the beta version](https://discordapp.com/oauth2/authorize?client_id=356856478495408129&scope=bot&permissions=537218112). Note that this may have bugs.
+
+!!! note
+  There is no difference between clusters 1 to 5.
+
+## How can I use a cluster?
+
+First, click on the link for a cluster and add the bot to your server.
+
+!!! note
+  The examples on this page use Cluster 1 (cl1), change it to the cluster you added to the server.
+  
+#### Jump to
+* [iframes](#iframes)
+* [crate](#crate)
+* [html-embed](#html-embed)
+* [react-embed](#react-embed)
+
+### iframes
+
+Preprend the cluster to the domain in the `src` url, for example `https://widgetbot.io/channels/34234/234432` => `https://cl4.widgetbot.io/channels/34234/234432`. For more info see [the iframe tutorial](/tutorial/iframes) (the cluster is the `shard`).
+
+!!! example "iframe example with cluster"
+  ```html
+ <iframe src="https://cl1.widgetbot.io/channels/299881420891881473/355719584830980096" height="600" width="800"></iframe>
+  ```
+
+### Crate
+
+Set the `shard` [option](/embed/crate/options):
+
+!!! example "Crate example with cluster"
+  ```html
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+  new Crate({
+    server: '299881420891881473',
+    channel: '355719584830980096',
+    shard: 'https://cl1.widgetbot.io'
+   })
+  </script>
+  ```
+  
+For more info see [the Crate tutorial](/embed/crate/tutorial).
+
+### html-embed
+
+Add a `shard` [attribute](/embed/html-embed/attributes)
+
+!!! example "html-embed example with cluster"
+  ```html
+  <widgetbot
+    server="299881420891881473"
+    channel="355719584830980096"
+    width="800"
+    height="600"
+    shard="https://cl1.widgetbot.io"
+  ></widgetbot>
+  <script src="https://cdn.jsdelivr.net/npm/@widgetbot/html-embed"></script>
+
+  ```
+
+For more info see [the html-embed tutorial](/embed/html-embed/tutorial).
+
+
+### react-embed
+
+Set the `shard` [prop](/embed/react-embed/props)
+
+!!! example "react-embed example with cluster"
+  ```js
+  import * as React from 'react'
+  import WidgetBot from '@widgetbot/react-embed'
+  
+  const App = () => (
+    <WidgetBot
+      server="299881420891881473"
+      channel="355719584830980096"
+      shard="https://cl1.widgetbot.io"
+   />
+  )
+
+  export default App
+  ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,9 +43,12 @@ pages:
     - react-embed:
       - Intro: embed/react-embed/index.md
       - Props: embed/react-embed/props.md
-  - Self hosted:
+  - Self-hosted:
       - Getting started: self-hosted/index.md
       - Configuration: self-hosted/config.md
+  - Guides:
+      - WidgetBot Guides: guides/index.md
+      - Move to a cluster: guides/move-to-cluster.md
 
 # Extensions
 markdown_extensions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs>=1
-mkdocs-material
+mkdocs
+mkdocs-material<=2.9.4
 markdown-include

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs
+mkdocs>=1
 mkdocs-material
 markdown-include


### PR DESCRIPTION
https://wbot-docs.advaith.fun/guides/move-to-cluster

Also:
* add guides section
* rename "self hosted" section to "self-hosted"
* Force mkdocs-material to use 2.x since 3.x requires mkdocs 1.0 which netlify doesnt support