### PR TITLE
Remove nonexisting function

### DIFF
--- a/embed/crate/api.md
+++ b/embed/crate/api.md
@@ -45,7 +45,7 @@ type notify = (
       content: string
       timeout?: number
     }
-  ) => { hide: Function; delete: Function }
+  ) => { hide: Function }
 ```
 :::
 Displays a notification message to the user. Markdown supported


### PR DESCRIPTION
Removed `delete` function of crate notifications, which is not implemented.

Maybe you want to consider renaming the `hide` function to `delete` in the next major version and add an option to decrement the unread count on delete.
The current implementation for `hide` is not a real hide, since the message can't be unhidden (which is fine, except for the naming).
Currently the only way to clear the crate notification icon without toggling the button is:
```js
crate.store.dispatch({ type: 'REMOVE_NOTIFICATION', payload: { decrement: true } })
```